### PR TITLE
Shuffle functions around such that JupyterHub isn't required to run script

### DIFF
--- a/hashauthenticator/hashauthenticator
+++ b/hashauthenticator/hashauthenticator
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 
-from hashauthenticator import generate_password_digest
+from passwordhash import generate_password_digest
 
 if __name__ == '__main__':
   if len(sys.argv) not in [3,4]:
@@ -10,12 +10,9 @@ if __name__ == '__main__':
 
   secret_key = sys.argv[1]
   username = sys.argv[2]
+  length = int(sys.argv[3]) if len(sys.argv) > 3 else 6
 
-  password = generate_password_digest(username, secret_key)
-
-  length = 6 
-  if len(sys.argv) == 4:
-    length = int(sys.argv[3])
+  password = generate_password_digest(username, secret_key, length)
 
   password = password[:length]
   print(password)

--- a/hashauthenticator/hashauthenticator.py
+++ b/hashauthenticator/hashauthenticator.py
@@ -1,14 +1,7 @@
 from jupyterhub.auth import Authenticator
 from tornado import gen
 from traitlets import Unicode, Integer
-import hashlib, binascii
-
-def generate_password_digest(username, secret_key):
-  dk = hashlib.pbkdf2_hmac('sha256', username.encode(), secret_key.encode(), 25000)
-  password_digest = binascii.hexlify(dk).decode()
-
-  return password_digest
-
+from passwordhash import generate_password_digest
 
 class HashAuthenticator(Authenticator):
   secret_key = Unicode(
@@ -26,8 +19,7 @@ class HashAuthenticator(Authenticator):
     username = data['username']
     password = data['password']
 
-    password_digest = generate_password_digest(username, self.secret_key)
-    expected_password = password_digest[:self.password_length]
+    expected_password = generate_password_digest(username, self.secret_key, self.password_length)
 
     if password == expected_password:
       return username

--- a/hashauthenticator/passwordhash.py
+++ b/hashauthenticator/passwordhash.py
@@ -1,0 +1,7 @@
+import hashlib, binascii
+
+def generate_password_digest(username, secret_key, length=6):
+  dk = hashlib.pbkdf2_hmac('sha256', username.encode(), secret_key.encode(), 25000)
+  password_digest = binascii.hexlify(dk).decode()
+
+  return password_digest[:length]


### PR DESCRIPTION
This way you don't have to install JupyterHub locally to be able to generate the passwords.