### PR TITLE
Provide CSV file with names and passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hash JupyterHub Authenticator
 
-An authenticator for [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) where the password for each user is a secure hash of its username. Useful for environments where it's not suitable for users to authenticate with their Google/GitHub/etc. acconunts.
+An authenticator for [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) where the password for each user is a secure hash of its username. Useful for environments where it's not suitable for users to authenticate with their Google/GitHub/etc. accounts.
 
 ## Installation
 
@@ -10,11 +10,12 @@ pip install jupyterhub-hashauthenticator
 
 Should install it. It has no additional dependencies beyond JupyterHub.
 
-You can then use this as your authenticator by adding the following line to your jupyterhub_config.py:
+You can then use this as your authenticator by adding the following lines to your `jupyterhub_config.py`:
 
 ```python
 c.JupyterHub.authenticator_class = 'hashauthenticator.HashAuthenticator
-c.HashAuthenticator.secret_key = 'my secret key'
+c.HashAuthenticator.secret_key = 'my secret key'  # Defaults to ''
+c.HashAuthenticator.password_length = 10          # Defaults to 6
 ```
 
 You can generate a good secret key with:
@@ -25,12 +26,32 @@ $ openssl rand -hex 32
 
 ## Generating the password
 
-This package comes with a command called `hashauthenticator`. Example usage:
+This package comes with a command called `hashauthpw`. Example usage:
 
 ```bash
-$ hashauthenticator
+$ hashauthpw
 Usage: hashauthenticator user [secret_key [len]]
 
-$ hashauthenticator my_key pminkov
+$ hashauthpw pminkov my_key
 939fd4
+```
+
+## JupyterHub service
+
+This package also provides a JupyterHub service which gives administrators a CSV containing all users and their passwords.  This can be used to generate login information for a group of users or to remind a user of their password.  In addition to JupyterHub, this service requires the *flask* and *requests* packages.
+
+It can be enabled through your `jupyterhub_config.py` file:
+
+```python
+c.JupyterHub.services = [
+  {
+    'name': 'hashauth',  # Service will be available at /services/hashauth
+    'admin': True,
+    'url': 'http://127.0.0.1:10101',          # The ports in this URL and
+    'command': ['hashauthservice', '10101'],  # command line must match
+    'environment': {
+      'CONFIG_FILE': 'jupyterhub_config.py'   # Path to this configuration file
+    }
+  }
+]
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This package comes with a command called `hashauthpw`. Example usage:
 
 ```bash
 $ hashauthpw
-Usage: hashauthenticator user [secret_key [len]]
+usage: hashauthpw [-h] [--length LENGTH] username [secret_key]
 
 $ hashauthpw pminkov my_key
 939fd4

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ c.JupyterHub.services = [
   {
     'name': 'hashauth',  # Service will be available at /services/hashauth
     'admin': True,
-    'url': 'http://127.0.0.1:10101',          # The ports in this URL and
-    'command': ['hashauthservice', '10101'],  # command line must match
+    'url': 'http://127.0.0.1:10101',  # Pick any free port
+    'command': ['hashauthservice'],
     'environment': {
-      'CONFIG_FILE': 'jupyterhub_config.py'   # Path to this configuration file
+      'CONFIG_FILE': 'jupyterhub_config.py'  # Path to this configuration file
     }
   }
 ]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ hashauthpw pminkov my_key
 
 ## JupyterHub service
 
-This package also provides a JupyterHub service which gives administrators a CSV containing all users and their passwords.  This can be used to generate login information for a group of users or to remind a user of their password.  In addition to JupyterHub, this service requires the *flask* and *requests* packages.
+This package also provides a JupyterHub service which gives administrators a CSV containing all users and their passwords.  This can be used to generate login information for a group of users or to remind a user of their password.  In addition to JupyterHub, this service requires the *requests* package.
 
 It can be enabled through your `jupyterhub_config.py` file:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package comes with a command called `hashauthenticator`. Example usage:
 
 ```bash
 $ hashauthenticator
-Usage: hashauthenticator secret_key user [len]
+Usage: hashauthenticator user [secret_key [len]]
 
 $ hashauthenticator my_key pminkov
 939fd4

--- a/hashauthenticator/__init__.py
+++ b/hashauthenticator/__init__.py
@@ -1,4 +1,11 @@
-from hashauthenticator.hashauthenticator import HashAuthenticator
-from hashauthenticator.hashauthenticator import generate_password_digest
+from .passwordhash import generate_password_digest
+# To let the password script be run where JupyterHub isn't installed:
+try:
+  from .hashauthenticator import HashAuthenticator
+except ImportError:
+  print("Warning: Unable to import HashAuthenticator.\n"
+        "Only generate_password_digest will be available.")
+  HashAuthenticator = None
 
-__all__ = [HashAuthenticator, generate_password_digest]
+
+__all__ = ['HashAuthenticator', 'generate_password_digest']

--- a/hashauthenticator/hashauthenticator.py
+++ b/hashauthenticator/hashauthenticator.py
@@ -1,7 +1,7 @@
 from jupyterhub.auth import Authenticator
 from tornado import gen
 from traitlets import Unicode, Integer
-from passwordhash import generate_password_digest
+from .passwordhash import generate_password_digest
 
 class HashAuthenticator(Authenticator):
   secret_key = Unicode(

--- a/hashauthenticator/hashauthservice
+++ b/hashauthenticator/hashauthservice
@@ -1,0 +1,72 @@
+import csv
+from functools import wraps
+from io import StringIO
+import os
+import sys
+from urllib.parse import quote
+
+from flask import Flask, redirect, request, Response
+import requests
+from traitlets.config import PyFileConfigLoader
+
+from jupyterhub.services.auth import HubAuth
+
+from passwordhash import generate_password_digest
+
+prefix = os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '/')
+api_token = os.environ['JUPYTERHUB_API_TOKEN']
+config_file = os.environ.get('CONFIG_FILE', 'jupyterhub_config.py')
+
+
+def generate_password_function():
+  config = PyFileConfigLoader(config_file).load_config()
+  hash_config = config.get('HashAuthenticator', dict())
+  secret_key = hash_config.get('secret_key', '')
+  password_length = hash_config.get('password_length', 6)
+  return lambda user: generate_password_digest(user, secret_key, password_length)
+
+get_password = generate_password_function()
+
+
+auth = HubAuth(api_token=api_token, cookie_cache_max_age=60)
+
+def authenticated_admin(f):
+  """Decorator for authenticating with the Hub"""
+  @wraps(f)
+  def decorated(*args, **kwargs):
+    cookie = request.cookies.get(auth.cookie_name)
+    if cookie:
+      user = auth.user_for_cookie(cookie)
+    else:
+      user = None
+    if user:
+      if user['admin']:
+        return f(user, *args, **kwargs)
+      else:
+        return "Unauthorized", 403
+    else:
+      # redirect to login url on failed auth
+      return redirect(auth.login_url + '?next=%s' % quote(request.path))
+  return decorated
+
+
+app = Flask(__name__)
+
+@app.route(prefix + '/')
+@authenticated_admin
+def hash(user):
+  resp = requests.get('http://localhost:8081/hub/api/users',
+                      headers={'Authorization': 'token {}'.format(api_token)})
+  users = sorted((u['name'], get_password(u['name'])) for u in resp.json())
+  buffer_ = StringIO()
+  csv.writer(buffer_).writerows(users)
+  return Response(buffer_.getvalue(), mimetype="text/plain")
+
+
+if __name__ == '__main__':
+  if len(sys.argv) != 2:
+    print("Usage: {} port".format(sys.argv[0]))
+    sys.exit(1)
+
+  port = sys.argv[1]
+  app.run(port=port)

--- a/scripts/hashauthpw
+++ b/scripts/hashauthpw
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 
-from passwordhash import generate_password_digest
+from hashauthenticator import generate_password_digest
 
 if __name__ == '__main__':
   if len(sys.argv) not in [3,4]:

--- a/scripts/hashauthpw
+++ b/scripts/hashauthpw
@@ -4,12 +4,12 @@ import sys
 from hashauthenticator import generate_password_digest
 
 if __name__ == '__main__':
-  if len(sys.argv) not in [3,4]:
-    print('Usage: hashauthenticator secret_key user [len]')
+  if len(sys.argv) not in [2,3,4]:
+    print('Usage: hashauthenticator user [secret_key [len]]')
     sys.exit(1)
 
-  secret_key = sys.argv[1]
-  username = sys.argv[2]
+  username = sys.argv[1]
+  secret_key = sys.argv[2] if len(sys.argv) > 2 else ''
   length = int(sys.argv[3]) if len(sys.argv) > 3 else 6
 
   password = generate_password_digest(username, secret_key, length)

--- a/scripts/hashauthpw
+++ b/scripts/hashauthpw
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
+import argparse
 import sys
 
 from hashauthenticator import generate_password_digest
 
 if __name__ == '__main__':
-  if len(sys.argv) not in [2,3,4]:
-    print('Usage: hashauthenticator user [secret_key [len]]')
-    sys.exit(1)
+  parser = argparse.ArgumentParser(description='Show the password for a user')
+  parser.add_argument('username', help='Username for JupyterHub')
+  parser.add_argument('secret_key', nargs='?', help='Salt for the hash', default='')
+  parser.add_argument('--length', '-l', type=int, help='Password length', default=6)
+  args = parser.parse_args()
 
-  username = sys.argv[1]
-  secret_key = sys.argv[2] if len(sys.argv) > 2 else ''
-  length = int(sys.argv[3]) if len(sys.argv) > 3 else 6
-
-  password = generate_password_digest(username, secret_key, length)
-
-  password = password[:length]
-  print(password)
+  print(generate_password_digest(args.username, args.secret_key, args.length))

--- a/scripts/hashauthservice
+++ b/scripts/hashauthservice
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import csv
 from functools import wraps
 from io import StringIO
@@ -11,7 +13,7 @@ from traitlets.config import PyFileConfigLoader
 
 from jupyterhub.services.auth import HubAuth
 
-from passwordhash import generate_password_digest
+from hashauthenticator import generate_password_digest
 
 prefix = os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '/')
 api_token = os.environ['JUPYTERHUB_API_TOKEN']

--- a/scripts/hashauthservice
+++ b/scripts/hashauthservice
@@ -2,16 +2,18 @@
 
 import csv
 from functools import wraps
-from io import StringIO
 import os
-import sys
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
-from flask import Flask, redirect, request, Response
 import requests
 from traitlets.config import PyFileConfigLoader
 
-from jupyterhub.services.auth import HubAuth
+from tornado.ioloop import IOLoop
+from tornado.httpserver import HTTPServer
+from tornado.web import RequestHandler, Application, authenticated, HTTPError
+
+from jupyterhub.services.auth import HubOAuthenticated, HubOAuthCallbackHandler
+from jupyterhub.utils import url_path_join
 
 from hashauthenticator import generate_password_digest
 
@@ -31,40 +33,29 @@ def generate_password_function():
 get_password = generate_password_function()
 
 
-auth = HubAuth(api_token=api_token, cookie_cache_max_age=60)
+class HashAuthHandler(HubOAuthenticated, RequestHandler):
 
-def authenticated_admin(f):
-  """Decorator for authenticating with the Hub"""
-  @wraps(f)
-  def decorated(*args, **kwargs):
-    cookie = request.cookies.get(auth.cookie_name)
-    if cookie:
-      user = auth.user_for_cookie(cookie)
-    else:
-      user = None
-    if user:
-      if user['admin']:
-        return f(user, *args, **kwargs)
-      else:
-        return "Unauthorized", 403
-    else:
-      # redirect to login url on failed auth
-      return redirect(auth.login_url + '?next=%s' % quote(request.path))
-  return decorated
+  @authenticated
+  def get(self):
+    if not self.get_current_user()['admin']:
+      raise HTTPError(403)
+
+    resp = requests.get('http://localhost:8081/hub/api/users',
+                        headers={'Authorization': 'token {}'.format(api_token)})
+    users = sorted((u['name'], get_password(u['name'])) for u in resp.json())
+    self.set_header('content-type', 'text/plain')
+    csv.writer(self).writerows(users)
 
 
-app = Flask(__name__)
+def main():
+  app = Application([
+    (prefix, HashAuthHandler),
+    (url_path_join(prefix, 'oauth_callback'), HubOAuthCallbackHandler)
+  ], cookie_secret=os.urandom(32))
 
-@app.route(prefix + '/')
-@authenticated_admin
-def hash(user):
-  resp = requests.get('http://localhost:8081/hub/api/users',
-                      headers={'Authorization': 'token {}'.format(api_token)})
-  users = sorted((u['name'], get_password(u['name'])) for u in resp.json())
-  buffer_ = StringIO()
-  csv.writer(buffer_).writerows(users)
-  return Response(buffer_.getvalue(), mimetype="text/plain")
+  HTTPServer(app).listen(service_url.port, service_url.hostname)
+  IOLoop.current().start()
 
 
 if __name__ == '__main__':
-  app.run(port=service_url.port)
+  main()

--- a/scripts/hashauthservice
+++ b/scripts/hashauthservice
@@ -5,7 +5,7 @@ from functools import wraps
 from io import StringIO
 import os
 import sys
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from flask import Flask, redirect, request, Response
 import requests
@@ -15,6 +15,7 @@ from jupyterhub.services.auth import HubAuth
 
 from hashauthenticator import generate_password_digest
 
+service_url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
 prefix = os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '/')
 api_token = os.environ['JUPYTERHUB_API_TOKEN']
 config_file = os.environ.get('CONFIG_FILE', 'jupyterhub_config.py')
@@ -66,9 +67,4 @@ def hash(user):
 
 
 if __name__ == '__main__':
-  if len(sys.argv) != 2:
-    print("Usage: {} port".format(sys.argv[0]))
-    sys.exit(1)
-
-  port = sys.argv[1]
-  app.run(port=port)
+  app.run(port=service_url.port)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/pminkov/jupyterhub-hashauthenticator',
     author='Petko Minkov',
     author_email='pminkov@gmail.com',
-    scripts=['hashauthenticator/hashauthenticator'],
+    scripts=['scripts/hashauthpw', 'scripts/hashauthservice'],
     install_requires=['jupyterhub'],
     test_suite="hashauthenticator.tests",
     license='BSD3',


### PR DESCRIPTION
@tianhuil, I don't know if you want to do code reviews here or not.  If you don't feel like it, I'll just merge it in now and have Zach and Chris look over this code carefully when I start to bring them up to speed on JH.

The main thrust of this code is to provide a JupyterHub service that reports (to admin users only) a CSV file full of names and passwords.  This will make getting set up for day 1 easier -- the teacher doesn't have to know the secret_key or even have downloaded this package.  They can just go to /services/hashauth/ and get everything they need.

Around that, there's a fair amount of cleanup I ended up doing, mainly related to getting the install working and improving the command line script.  I don't think those things particularly need review.