### PR TITLE
Allow login with Google Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ An authenticator for [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) 
 pip install jupyterhub-hashauthenticator
 ```
 
-Should install it. It has no additional dependencies beyond JupyterHub and its dependencies.
+Should install it. It has no additional dependencies beyond JupyterHub, oauthenticator, and their dependencies.
 
-You can then use this as your authenticator by adding the following lines to your `jupyterhub_config.py`:
+## Basic usage
+
+The package provides a basic `HashAuthenticator` class, which requires all users to log in with their hash password.  You can use this as your authenticator by adding the following lines to your `jupyterhub_config.py`:
 
 ```python
 c.JupyterHub.authenticator_class = 'hashauthenticator.HashAuthenticator
@@ -26,6 +28,24 @@ $ openssl rand -hex 32
 ```
 
 If the `show_logins` option is set to true, a CSV file containing login names and passwords will be served (to admins only) at `/hub/login_list`.
+
+## Advanced usage
+
+You may also combine the hash authenticator for standard users with an existing authenticator for admin users.  The `make_hash_authenticator` function can create a new class with this bifurcated login system.  It takes two arguments, the name of the new class (important for use in configuration files) and the Authenticator class to be used for admin users.
+
+The function should work with any Authenticator that defines a `.login_url` attribute, instead of relying on the username/password entry form.  To get to that URL, you must enter a username in that entry form that is recognized as an admin name by virtue of ending with the *admin_suffix*, which defaults to `@`.  That username is not actually used (so you can just enter the suffix on its own)&mdash;instead the admin authenticator takes over.  The username returned by that will thave the *admin_suffix* appended for JupyterHub.  These users will be added to the JupyterHub whitelist, if one is in use.
+
+A mixed authenticator using Google's OAuthenticator has already been constructed, as `GoogleHashAuthenticator`.  Below is an outline of the necessary configuration to use it.
+
+```python
+c.JupyterHub.authenticator_class = 'hashauthenticator.GoogleHashAuthenticator'
+c.GoogleHashAuthenticator.secret_key = "my secret key"
+c.GoogleHashAuthenticator.password_length = 10
+c.GoogleHashAuthenticator.oauth_callback_url = 'http://<jupyterhub URL>/hub/oauth_callback'
+c.GoogleHashAuthenticator.client_id = 'client ID'
+c.GoogleHashAuthenticator.client_secret = 'client secret'
+c.GoogleHashAuthenticator.hosted_domain = 'company.com'
+```
 
 ## Generating the password
 

--- a/hashauthenticator/__init__.py
+++ b/hashauthenticator/__init__.py
@@ -1,11 +1,13 @@
 from .passwordhash import generate_password_digest
 # To let the password script be run where JupyterHub isn't installed:
 try:
-  from .hashauthenticator import HashAuthenticator
-except ImportError:
+  from .hashauthenticator import HashAuthenticator, GoogleHashAuthenticator, make_hash_authenticator
+except ImportError as e:
   print("Warning: Unable to import HashAuthenticator.\n"
         "Only generate_password_digest will be available.")
   HashAuthenticator = None
+  GoogleHashAuthenticator = None
+  make_hash_authenticator = None
 
 
-__all__ = ['HashAuthenticator', 'generate_password_digest']
+__all__ = ['HashAuthenticator', 'GoogleHashAuthenticator', 'make_hash_authenticator', 'generate_password_digest']

--- a/hashauthenticator/hashauthenticator.py
+++ b/hashauthenticator/hashauthenticator.py
@@ -74,6 +74,11 @@ def make_hash_authenticator(class_name, AdminAuthenticator=None):
           raise HTTPError(503, "Incorrect authentication")
 
         retval = yield super().authenticate(handler, data)
+        if retval is None:
+          return None
+        if isinstance(retval, str):
+          retval = {'name': retval}
+
         retval['name'] += self.admin_suffix
         retval['admin'] = True
         if self.whitelist:

--- a/hashauthenticator/hashauthenticator.py
+++ b/hashauthenticator/hashauthenticator.py
@@ -8,7 +8,7 @@ from oauthenticator.google import GoogleOAuthenticator
 from tornado import gen
 from tornado.httputil import url_concat
 from tornado.web import Finish, HTTPError
-from traitlets import Unicode, Integer, Bool
+from traitlets import Unicode, Integer, Bool, default
 
 from .passwordhash import generate_password_digest
 
@@ -54,6 +54,11 @@ def make_hash_authenticator(class_name, AdminAuthenticator=None):
       config=True,
       help="A suffix to separate users logged in through the admin authenticator."
     )
+
+    @default('login_service')
+    def default_login_service(self):
+      # Show the username/password entry
+      return ''
 
     def get_password(self, username):
       return generate_password_digest(username, self.secret_key, self.password_length)

--- a/hashauthenticator/hashauthenticator.py
+++ b/hashauthenticator/hashauthenticator.py
@@ -76,6 +76,8 @@ def make_hash_authenticator(class_name, AdminAuthenticator=None):
         retval = yield super().authenticate(handler, data)
         retval['name'] += self.admin_suffix
         retval['admin'] = True
+        if self.whitelist:
+          self.whitelist.add(retval['name'])
         return retval
 
       username = data['username']

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     maintainer='Robert Schroll',
     maintainer_email='robert@thedataincubator.com',
     scripts=['scripts/hashauthpw'],
-    install_requires=['jupyterhub', 'tornado', 'traitlets'],
+    install_requires=['jupyterhub', 'tornado', 'traitlets', 'oauthenticator'],
     test_suite="hashauthenticator.tests",
     license='BSD3',
     packages=['hashauthenticator'],


### PR DESCRIPTION
Allows us to create new bifurcated authenticators that use the hash mechanism for standard users and some other for admin users.  Using the GoogleOAuthenticator with this, we can let us log in with our company accounts, while students still use the hash system.

@ZachGlassman I would like another set of eyes on this, but this has turned into dense code.  If you're not familiar with how authenticators work, it'll be a slog to go through.  So maybe we can chat sometime and I'll talk you through the flow.